### PR TITLE
Bring in policy evaluator and check user credentials

### DIFF
--- a/systemlink-notebook-datasource/package-lock.json
+++ b/systemlink-notebook-datasource/package-lock.json
@@ -2327,6 +2327,12 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@ni-kismet/helium-uicomponents": {
+      "version": "1.323.0",
+      "resolved": "https://registry.npmjs.org/@ni-kismet/helium-uicomponents/-/helium-uicomponents-1.323.0.tgz",
+      "integrity": "sha512-GFcZ1NB+qBbPIk3vrD2UiaTgX23/kvXf8kOCYyxC952c/gALbPAxlNPFZydtJODqQ/ERfIDbMXVy4xM+hB8M7A==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/systemlink-notebook-datasource/package.json
+++ b/systemlink-notebook-datasource/package.json
@@ -15,6 +15,7 @@
     "@grafana/runtime": "^7.1.1",
     "@grafana/toolkit": "^7.1.1",
     "@grafana/ui": "^7.1.1",
+    "@ni-kismet/helium-uicomponents": "^1.323.0",
     "@testing-library/jest-dom": "5.4.0",
     "@testing-library/react": "^10.0.2",
     "@types/lodash": "latest"

--- a/systemlink-notebook-datasource/src/types/@ni-kismet/helium-uicomponents/index.d.ts
+++ b/systemlink-notebook-datasource/src/types/@ni-kismet/helium-uicomponents/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@ni-kismet/helium-uicomponents/library/policyevaluator';


### PR DESCRIPTION
This PR makes the notebook datasource configuration check the validity of a user's credentials as noted by Ryan in AB#1064444. I also brought in the policy evaluator component to see if the user has the privileges to query and execute notebooks. 
There's an essentially unfixable bug (https://github.com/grafana/grafana/issues/15050): If a user enters the wrong user/pass, the browser will open its native login dialog. Entering the correct credentials in this dialog will not update the datasource configuration. 