### PR TITLE
Add datasource help + some other little fixes

### DIFF
--- a/plotly-panel/src/PlotlyPanel.tsx
+++ b/plotly-panel/src/PlotlyPanel.tsx
@@ -28,7 +28,7 @@ export const PlotlyPanel: React.FC<Props> = props => {
       layout={{
         width,
         height,
-        annotations: plotData.length === 0 ? [{ text: 'No data', showarrow: false }] : [],
+        annotations: plotData.length === 0 || !plotData.find(d => d.y?.length) ? [{ text: 'No data', showarrow: false }] : [],
         ...getLayout(theme, options),
       }}
       config={{ displayModeBar: false }}

--- a/systemlink-notebook-datasource/README.md
+++ b/systemlink-notebook-datasource/README.md
@@ -2,4 +2,4 @@
 
 This plugin supports loading SystemLink Notebook results into Grafana.
 
-For more information, see https://www.ni.com/documentation/en/systemlink/latest/data/reporting-data-with-jupyter-notebooks/.
+For more information, see the [documentation](https://ni.com/r/sljupyter) on ni.com.

--- a/systemlink-notebook-datasource/src/DataSource.test.ts
+++ b/systemlink-notebook-datasource/src/DataSource.test.ts
@@ -163,10 +163,12 @@ describe('Notebook data source', () => {
   });
 
   describe('query', () => {
-    it('throws error for no query', async () => {
+    it('returns no data for no query', async () => {
       const options = ({ targets: [{}] } as unknown) as DataQueryRequest<NotebookQuery>;
 
-      expect(ds.query(options)).rejects.toThrow();
+      let result = await ds.query(options);
+
+      expect(result.data.length).toBe(0);
     });
 
     it('returns frame for successful notebook execution', async () => {

--- a/systemlink-notebook-datasource/src/DataSource.ts
+++ b/systemlink-notebook-datasource/src/DataSource.ts
@@ -164,7 +164,7 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
   }
 
   async queryNotebooks(path: string): Promise<Notebook[]> {
-    const filter = `path.Contains("${path}")`;
+    const filter = `path.Contains("${path}") && !metadata["namespaces"].Contains("ni-testmanagement-parametric-data-statistics")`;
     try {
       const response = await getBackendSrv().post(this.url + '/ninbexec/v2/query-notebooks', { filter });
       const notebooks = response.notebooks as Notebook[];


### PR DESCRIPTION
1. I added a super boring readme, but at least it doesn't say "how to make plugins".

This shows up if you click on the question mark next to the datasource dropdown:
![image](https://user-images.githubusercontent.com/32167177/96785466-73a27600-13b4-11eb-80bf-ed09b43b1333.png)
![image](https://user-images.githubusercontent.com/32167177/97925531-295fb400-1d27-11eb-95b3-a3abb1a0c23c.png)

I ran this by Jenna, and she likes it. We are pending the info code being final, so it will be broken for a bit.

2. A test was silently failing (thanks, Jest) and I fixed it.
3. The "no data" thing wasn't showing up when there wasn't data.
