### PR TITLE
Fix lint errors and a couple small changes

### DIFF
--- a/systemlink-notebook-datasource/src/DataSource.test.ts
+++ b/systemlink-notebook-datasource/src/DataSource.test.ts
@@ -106,7 +106,7 @@ describe('Notebook data source', () => {
       expect(result.name).toBe('plot1');
       expect(result.fields).toHaveLength(2);
       expect(result.length).toBe(4);
-      expect(result.get(0)).toEqual({ 'Field 2': 950, 'Index': 0 });
+      expect(result.get(0)).toEqual({ 'Field 2': 950, Index: 0 });
     });
 
     it('transforms scalar data', () => {
@@ -205,11 +205,13 @@ describe('Notebook data source', () => {
 
     it('throws error for notebook execution with invalid output', async () => {
       const options = ({
-        targets: [{
-          path: invalidNotebookPath,
-          parameters: [],
-          output: 'test'
-        }]
+        targets: [
+          {
+            path: invalidNotebookPath,
+            parameters: [],
+            output: 'test',
+          },
+        ],
       } as unknown) as DataQueryRequest<NotebookQuery>;
 
       expect(ds.query(options)).rejects.toThrow();
@@ -282,12 +284,12 @@ function mockNotebookApiResponse(options: any) {
                 id: 'test',
                 type: 'data_frame',
                 data: {
-                  values: [1, 2, 3]
-                }
-              }
-            ]
-          }
-        }
+                  values: [1, 2, 3],
+                },
+              },
+            ],
+          },
+        },
       };
     default:
       return {};

--- a/systemlink-notebook-datasource/src/DataSource.ts
+++ b/systemlink-notebook-datasource/src/DataSource.ts
@@ -62,7 +62,7 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
           return { data: frames, error };
         }
       } else {
-        throw new Error('The output for the notebook does not match the expected SystemLink format.')
+        throw new Error('The output for the notebook does not match the expected SystemLink format.');
       }
     } else {
       throw new Error('The notebook failed to execute.');
@@ -126,8 +126,10 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
   }
 
   private getFieldType(type: string): FieldType {
-    if (type === 'string' || type === 'number' || type === 'boolean') {
+    if (type === 'string' || type === 'boolean') {
       return FieldType[type];
+    } else if (type === 'number' || type === 'integer') {
+      return FieldType.number;
     } else if (type === 'datetime') {
       return FieldType.time;
     } else {

--- a/systemlink-notebook-datasource/src/QueryEditor.tsx
+++ b/systemlink-notebook-datasource/src/QueryEditor.tsx
@@ -12,7 +12,10 @@ import './QueryEditor.scss';
 
 type Props = QueryEditorProps<DataSource, NotebookQuery, NotebookDataSourceOptions>;
 
-export class QueryEditor extends PureComponent<Props, { notebooks: Notebook[]; isLoading: boolean; queryError: string }> {
+export class QueryEditor extends PureComponent<
+  Props,
+  { notebooks: Notebook[]; isLoading: boolean; queryError: string }
+> {
   constructor(props: Props) {
     super(props);
     this.state = { notebooks: [], isLoading: true, queryError: '' };
@@ -88,7 +91,7 @@ export class QueryEditor extends PureComponent<Props, { notebooks: Notebook[]; i
     const selectedNotebook = this.getNotebook(query.path) as Notebook;
     const value = query.parameters[param.id] || selectedNotebook.parameters[param.id];
     return (
-      <div className="sl-parameter" key={param.id}>
+      <div className="sl-parameter" key={param.id + selectedNotebook.path}>
         <Label className="sl-parameter-label">{param.display_name}</Label>
         {this.getParameterInput(param, value)}
       </div>
@@ -136,25 +139,24 @@ export class QueryEditor extends PureComponent<Props, { notebooks: Notebook[]; i
             value={selectedNotebook ? this.formatNotebookOption(selectedNotebook) : undefined}
           />
         </Field>
-        {this.state.queryError &&
-          <Alert title={this.state.queryError}>
-          </Alert>
-        }
-        {selectedNotebook && selectedNotebook.metadata.parameters && selectedNotebook.metadata.parameters.length && [
-          <div className="sl-parameters">
-            <Label>Parameters</Label>
-            {selectedNotebook.metadata.parameters.map(this.getParameter)}
-          </div>,
-          <Field className="sl-output" label="Output">
-            <Select
-              options={selectedNotebook.metadata.outputs.map(this.formatOutputOption)}
-              onChange={this.onOutputChange}
-              value={this.formatOutputOption(
-                selectedNotebook.metadata.outputs.find((output: any) => output.id === query.output)
-              )}
-            />
-          </Field>,
-        ]}
+        {this.state.queryError && <Alert title={this.state.queryError}></Alert>}
+        {selectedNotebook &&
+          selectedNotebook.metadata.parameters &&
+          selectedNotebook.metadata.parameters.length && [
+            <div className="sl-parameters">
+              <Label>Parameters</Label>
+              {selectedNotebook.metadata.parameters.map(this.getParameter)}
+            </div>,
+            <Field className="sl-output" label="Output">
+              <Select
+                options={selectedNotebook.metadata.outputs.map(this.formatOutputOption)}
+                onChange={this.onOutputChange}
+                value={this.formatOutputOption(
+                  selectedNotebook.metadata.outputs.find((output: any) => output.id === query.output)
+                )}
+              />
+            </Field>,
+          ]}
       </div>
     );
   }


### PR DESCRIPTION
This fixes the lint errors that only seem to correctly report on my Mac. I've asked the Grafana slack about it but received no response yet. 
This also has a couple changes
- Handles 'integer' column type from notebooks
- Fixes a bug where parameter values wouldn't reset to defaults when picking a different notebook with the same parameter options