### PR TITLE
Preserve parameter values when changing notebooks

### DIFF
--- a/systemlink-notebook-datasource/src/QueryEditor.scss
+++ b/systemlink-notebook-datasource/src/QueryEditor.scss
@@ -22,7 +22,7 @@
             }
 
             .sl-parameter-value {
-                flex: 2;
+                flex-basis: 66%;
             }
         }
     }

--- a/systemlink-notebook-datasource/src/QueryEditor.tsx
+++ b/systemlink-notebook-datasource/src/QueryEditor.tsx
@@ -5,7 +5,7 @@
 import defaults from 'lodash/defaults';
 import pickBy from 'lodash/pickBy';
 import React, { PureComponent } from 'react';
-import { Alert, Field, Input, Select, Label } from '@grafana/ui';
+import { Alert, Field, Input, Select, Label, TextArea } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './DataSource';
 import { NotebookDataSourceOptions, NotebookQuery, defaultQuery, Notebook } from './types';
@@ -52,7 +52,24 @@ export class QueryEditor extends PureComponent<
   onNotebookChange = (option: SelectableValue) => {
     const { onChange, onRunQuery, query } = this.props;
     const notebook = this.getNotebook(option.value) as Notebook;
-    const parameters = pickBy(query.parameters, (_, key) => notebook.parameters.hasOwnProperty(key));
+    const oldNotebook = this.getNotebook(query.path);
+    let parameters = {};
+    if (oldNotebook) {
+      // Preseve matching parameter values
+      parameters = pickBy(query.parameters, (value: any, id: string) => {
+        const newParam = notebook.metadata.parameters.find((param: any) => param.id === id);
+        if (!newParam) {
+          return false;
+        }
+
+        if (newParam.options) {
+          return newParam.options.includes(value);
+        }
+
+        const oldParam = oldNotebook.metadata.parameters.find((param: any) => param.id === id);
+        return oldParam.type === newParam.type;
+      });
+    }
     onChange({ ...query, parameters, path: notebook.path, output: notebook.metadata.outputs[0].id });
     onRunQuery();
   };
@@ -111,6 +128,14 @@ export class QueryEditor extends PureComponent<
           defaultValue={{ label: value, value }}
           menuPlacement="auto"
           maxMenuHeight={110}
+        />
+      );
+    } else if (param.type === 'test_monitor_result_query') {
+      return (
+        <TextArea
+          className="sl-parameter-value"
+          onBlur={event => this.onParameterChange(param.id, event.target.value)}
+          defaultValue={value}
         />
       );
     } else {


### PR DESCRIPTION
Pretty straightforward request from Ryan: if a user changes the selected notebook and there are parameters with the same name as the previous notebook, we should preserve any entered values. 