### PR TITLE
Allow Grafana variables as enum options

### DIFF
--- a/systemlink-notebook-datasource/src/QueryEditor.tsx
+++ b/systemlink-notebook-datasource/src/QueryEditor.tsx
@@ -129,7 +129,6 @@ export class QueryEditor extends PureComponent<
       return (
         <Select
           className="sl-parameter-value"
-          allowCustomValue
           options={options}
           onChange={event => this.onParameterChange(param.id, event.value as string)}
           defaultValue={{ label: value, value }}


### PR DESCRIPTION
This adds a dashboard's variables as potential options for an enumerated parameter on a notebook.