### PR TITLE
Add Horizontal display option

### DIFF
--- a/plotly-panel/src/module.ts
+++ b/plotly-panel/src/module.ts
@@ -298,21 +298,21 @@ export const plugin = new PanelPlugin<PanelOptions>(PlotlyPanel)
         defaultValue: 'right',
       })
       .addRadio({
-        path: 'orientation',
+        path: 'displayVertically',
         name: 'Orientation',
         settings: {
           options: [
-            { label: 'Vertical', value: 'vertical' },
-            { label: 'Horizontal', value: 'horizontal' },
+            { label: 'Vertical', value: true },
+            { label: 'Horizontal', value: false },
           ],
         },
-        defaultValue: 'vertical',
+        defaultValue: true,
       })
       .addBooleanSwitch({
         path: 'invertXAxis',
         name: 'Invert X axis',
         defaultValue: true,
-        showIf: options => options.orientation === 'horizontal',
+        showIf: options => options.displayVertically === false,
       });
   })
   .useFieldConfig({

--- a/plotly-panel/src/types.ts
+++ b/plotly-panel/src/types.ts
@@ -5,7 +5,7 @@ export interface PanelOptions {
   showYAxis2: boolean;
   showLegend: boolean;
   legendPosition: string;
-  orientation: string;
+  displayVertically: boolean;
   invertXAxis: boolean;
   series: SeriesOptions;
   series2: SeriesOptions;


### PR DESCRIPTION
Summary:
* Added Orientation option for Vertical vs Horizontal under Display
* Added an option "Invert X axis" that appears when the Orientation is Horizontal
* Renamed "Right Y Axis" to "Secondary Y Axis", since it appears at the top when the graph is Horizontal

![HorizontalOption](https://user-images.githubusercontent.com/14191691/101411114-0c7a4b80-38a6-11eb-848c-1c320a92f561.png)

The Orientation option under Display allows the user to choose between Vertical (the default) and Horizontal. When the Horizontal orientation is chosen, the data is plotted horizontally and the axes are flipped (e.g., the user configuration for the X Axis Label is used on the graph's Y Axis).

When Horizontal is chosen, an additional option "Invert x axis" appears that inverts the "x" axis by default. Ryan felt that the values that had been on the left of the x axis should move to the top of the graph when displayed horizontally because we read left to right and top to bottom.

Vertical graph:
![Vertical-OneY](https://user-images.githubusercontent.com/14191691/101411992-7515f800-38a7-11eb-9d99-34995081cc19.png)

Horizontal graph:
![Horizontal-OneY](https://user-images.githubusercontent.com/14191691/101412101-a5f62d00-38a7-11eb-90a8-72e311414aa7.png)

Horizontal graph, with Invert x axis disabled:
![Horizontal-OneY-NotInverted](https://user-images.githubusercontent.com/14191691/101412231-d938bc00-38a7-11eb-9943-ff1ba77e5200.png)

The Secondary Y Axis appears on the right when the graph is Vertical and on the top when the graph is Horizontal.
Vertical:
![Vertical-Pareto](https://user-images.githubusercontent.com/14191691/101413071-426cff00-38a9-11eb-8678-59be8080c8f8.png)

Horizontal:
![Horizontal-Pareto](https://user-images.githubusercontent.com/14191691/101413078-4731b300-38a9-11eb-8383-15058c501790.png)
