### PR TITLE
Add more x axis options and support for single-sided range

### DIFF
--- a/plotly-panel/src/module.ts
+++ b/plotly-panel/src/module.ts
@@ -35,6 +35,37 @@ export const plugin = new PanelPlugin<PanelOptions>(PlotlyPanel)
         defaultValue: '',
         category: ['X Axis'],
       })
+      .addNumberInput({
+        path: 'xAxis.min',
+        name: 'Min',
+        settings: {
+          placeholder: 'auto',
+        },
+        category: ['X Axis'],
+      })
+      .addNumberInput({
+        path: 'xAxis.max',
+        name: 'Max',
+        settings: {
+          placeholder: 'auto',
+        },
+        category: ['X Axis'],
+      })
+      .addNumberInput({
+        path: 'xAxis.decimals',
+        name: 'Decimals',
+        settings: {
+          placeholder: 'auto',
+          min: 0,
+        },
+        category: ['X Axis'],
+      })
+      .addTextInput({
+        path: 'xAxis.unit',
+        name: 'Unit',
+        defaultValue: '',
+        category: ['X Axis'],
+      })
       .addCustomEditor({
         path: 'yAxis.fields',
         editor: MultiSelectValueEditor as any,


### PR DESCRIPTION
- Expand X options to match Y (units, max/min, etc) with the exception of plot types
- Allow for single-ended min/max definition. For example: given 0 as a min, max can still be set to auto and vice versa.

I'm not sure what benefit we get from having min/max and decimals on the x-axis, so I'll check in with Ryan again before moving forward with this PR.