### PR TITLE
Multi-select fixes

### DIFF
--- a/plotly-panel/src/PlotlyPanel.tsx
+++ b/plotly-panel/src/PlotlyPanel.tsx
@@ -200,11 +200,6 @@ const getYFields = (selection: string[], frame: DataFrame, xField: Field | undef
   let yFields: Field[] = [];
   for (const yField of selection || []) {
     let selectedYField = frame.fields.find(field => field.name === yField);
-    if (!selectedYField && autoFill) {
-      selectedYField = frame.fields.find(
-        field => field !== xField && field.type !== FieldType.time && !yFields.includes(field)
-      );
-    }
     if (selectedYField) {
       yFields.push(selectedYField);
     }


### PR DESCRIPTION
Issue 1: the plotly panel used to crash if you added dataframes with different x fields.
Fix: Move `props.onOptionsChange` out of `getFields` so it can't get called once per frame.

Issue 2: the auto-select behavior for y fields wouldn't let you remove any fields if there were multiple notebooks on the graph.
Fix: Only auto-fill if there isn't a selection, which happens on initial load and if you manually remove all the fields. There's a little less magic now, but the user has more control over what is on the graph.