### PR TITLE
Default TM example fixes

### DIFF
--- a/examples/Default Test Module.json
+++ b/examples/Default Test Module.json
@@ -58,7 +58,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1608055072346,
+  "iteration": 1608232239692,
   "links": [],
   "panels": [
     {
@@ -224,7 +224,8 @@
         "xAxis": {
           "field": " ",
           "scale": "",
-          "title": ""
+          "title": "",
+          "unit": ""
         },
         "yAxis": {
           "fields": [
@@ -564,7 +565,8 @@
         "xAxis": {
           "field": "started_at",
           "scale": "",
-          "title": "$Grouping"
+          "title": "$Grouping",
+          "unit": ""
         },
         "yAxis": {
           "field": "yield",
@@ -581,7 +583,6 @@
           "fields": [
             "throughput"
           ],
-          "max": 500,
           "min": 0,
           "scale": "",
           "title": "Throughput",
@@ -897,5 +898,5 @@
   "timezone": "",
   "title": "Default Test Module",
   "uid": "4XS18YTMk",
-  "version": 58
+  "version": 1
 }

--- a/examples/KPIs.ipynb
+++ b/examples/KPIs.ipynb
@@ -120,7 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "results_filter = 'partNumber == \"HR-3UTG-AMZN\" && startedWithin <= \"30.0:0:0\"'\n",
+    "results_filter = 'startedWithin <= \"30.0:0:0\"'\n",
     "products_filter = ''\n",
     "group_by = 'Day'"
    ]


### PR DESCRIPTION
- Changes the results_filter parameter default to not include a part number
- Removes the arbitrary Y Axis Max of 500 for the throughput plot (possible due to https://github.com/ni-kismet/grafana-plugins/pull/24)