### PR TITLE
Add toggle to switch query builder into text input

### DIFF
--- a/systemlink-notebook-datasource/src/QueryEditor.scss
+++ b/systemlink-notebook-datasource/src/QueryEditor.scss
@@ -31,6 +31,14 @@
             }
         }
     }
+
+    .sl-label-button {
+        display: flex;
+
+        button {
+            margin-left: 6px;
+        }
+    }
 }
 
 body {

--- a/systemlink-notebook-datasource/src/QueryEditor.tsx
+++ b/systemlink-notebook-datasource/src/QueryEditor.tsx
@@ -5,7 +5,7 @@
 import defaults from 'lodash/defaults';
 import pickBy from 'lodash/pickBy';
 import React, { PureComponent } from 'react';
-import { Alert, Field, Input, Select, Label } from '@grafana/ui';
+import { Alert, Field, Input, Select, Label, IconButton, TextArea } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from './DataSource';
@@ -18,11 +18,11 @@ type Props = QueryEditorProps<DataSource, NotebookQuery, NotebookDataSourceOptio
 
 export class QueryEditor extends PureComponent<
   Props,
-  { notebooks: Notebook[]; isLoading: boolean; queryError: string }
+  { notebooks: Notebook[]; isLoading: boolean; queryError: string; showTextQuery: boolean }
 > {
   constructor(props: Props) {
     super(props);
-    this.state = { notebooks: [], isLoading: true, queryError: '' };
+    this.state = { notebooks: [], isLoading: true, queryError: '', showTextQuery: false };
   }
 
   async componentDidMount() {
@@ -106,13 +106,25 @@ export class QueryEditor extends PureComponent<
     const value = query.parameters[param.id] || selectedNotebook.parameters[param.id];
     if (param.type === 'test_monitor_result_query') {
       return (
-        <Field label={param.display_name} key={param.id + selectedNotebook.path}>
-          <TestResultsQueryBuilder
-            autoComplete={this.props.datasource.queryTestResultValues.bind(this.props.datasource)}
-            onChange={(event: any) => this.onParameterChange(param.id, event.detail.linq)}
-            defaultValue={value}
-          />
-        </Field>
+        <div key={param.id + selectedNotebook.path}>
+          <div className="sl-label-button">
+            <Label>{param.display_name}</Label>
+            <IconButton
+              name={this.state.showTextQuery ? 'list-ul' : 'pen'}
+              size="sm"
+              onClick={() => this.setState({ showTextQuery: !this.state.showTextQuery })}
+            />
+          </div>
+          {this.state.showTextQuery ? (
+            <TextArea defaultValue={value} onBlur={event => this.onParameterChange(param.id, event.target.value)} />
+          ) : (
+            <TestResultsQueryBuilder
+              autoComplete={this.props.datasource.queryTestResultValues.bind(this.props.datasource)}
+              onChange={(event: any) => this.onParameterChange(param.id, event.detail.linq)}
+              defaultValue={value}
+            />
+          )}
+        </div>
       );
     }
 


### PR DESCRIPTION
This lets users get to a text area in order to manually edit test result LINQ queries.

<img width="655" alt="Screen Shot 2021-02-11 at 5 39 34 PM" src="https://user-images.githubusercontent.com/9257800/107713103-2a8e6e80-6c90-11eb-9a11-0e65f4fec213.png">
<img width="477" alt="Screen Shot 2021-02-11 at 5 39 43 PM" src="https://user-images.githubusercontent.com/9257800/107713109-2c583200-6c90-11eb-83ac-f6a4869d9a0f.png">
