### PR TITLE
Fix package-lock.json out of sync

### DIFF
--- a/systemlink-notebook-datasource/package-lock.json
+++ b/systemlink-notebook-datasource/package-lock.json
@@ -2947,6 +2947,12 @@
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",

--- a/systemlink-notebook-datasource/src/ConfigEditor.tsx
+++ b/systemlink-notebook-datasource/src/ConfigEditor.tsx
@@ -19,7 +19,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
     return (
       <DataSourceHttpSettings
-        defaultUrl=" "
+        defaultUrl=""
         dataSourceConfig={options}
         showAccessOptions={false}
         onChange={onOptionsChange}


### PR DESCRIPTION
Somehow the package-lock of the notebook datasource got of sync and was causing the build to fail.  A simple `npm install` fixed it.