### PR TITLE
Support UTC time parsing for notebooks

### DIFF
--- a/systemlink-notebook-datasource/src/DataSource.test.ts
+++ b/systemlink-notebook-datasource/src/DataSource.test.ts
@@ -32,6 +32,13 @@ describe('Notebook data source', () => {
   const instanceSettings = ({
     url: 'http://test',
   } as unknown) as DataSourceInstanceSettings<NotebookDataSourceOptions>;
+  const mockQuery = {
+    refId: '123',
+    path: '/test/notebook',
+    parameters: null,
+    output: 'test_output',
+    cacheTimeout: 0,
+  };
 
   beforeEach(() => {
     ds = new DataSource(instanceSettings);
@@ -39,13 +46,6 @@ describe('Notebook data source', () => {
 
   describe('transformResultToDataFrames', () => {
     it('transforms xy data', () => {
-      let query = {
-        refId: '123',
-        path: '/test/notebook',
-        parameters: null,
-        output: 'test_output',
-        cacheTimeout: 0,
-      };
       let dataFrame = {
         type: 'data_frame',
         id: 'horizontal_graph',
@@ -67,7 +67,7 @@ describe('Notebook data source', () => {
         },
       };
 
-      let [result] = ds.transformResultToDataFrames(dataFrame, query);
+      let [result] = ds.transformResultToDataFrames(dataFrame, mockQuery);
 
       expect(result.name).toBe('plot1');
       expect(result.fields).toHaveLength(2);
@@ -76,13 +76,6 @@ describe('Notebook data source', () => {
     });
 
     it('transforms index data', () => {
-      let query = {
-        refId: '123',
-        path: '/test/notebook',
-        parameters: null,
-        output: 'test_output',
-        cacheTimeout: 0,
-      };
       let dataFrame = {
         type: 'data_frame',
         id: 'horizontal_graph',
@@ -104,7 +97,7 @@ describe('Notebook data source', () => {
         },
       };
 
-      let [result] = ds.transformResultToDataFrames(dataFrame, query);
+      let [result] = ds.transformResultToDataFrames(dataFrame, mockQuery);
 
       expect(result.name).toBe('plot1');
       expect(result.fields).toHaveLength(2);
@@ -113,16 +106,9 @@ describe('Notebook data source', () => {
     });
 
     it('transforms scalar data', () => {
-      let query = {
-        refId: '123',
-        path: '/test/notebook',
-        parameters: null,
-        output: 'test_output',
-        cacheTimeout: 0,
-      };
       let dataFrame = { type: 'scalar', id: 'output1', value: 2.5 };
 
-      let [result] = ds.transformResultToDataFrames(dataFrame, query);
+      let [result] = ds.transformResultToDataFrames(dataFrame, mockQuery);
 
       expect(result.fields).toHaveLength(1);
       expect(result.length).toBe(1);
@@ -130,13 +116,6 @@ describe('Notebook data source', () => {
     });
 
     it('transforms tabular data', () => {
-      let query = {
-        refId: '123',
-        path: '/test/notebook',
-        parameters: null,
-        output: 'test_output',
-        cacheTimeout: 0,
-      };
       let dataFrame = {
         type: 'data_frame',
         id: 'test_output',
@@ -153,7 +132,7 @@ describe('Notebook data source', () => {
         },
       };
 
-      let [result] = ds.transformResultToDataFrames(dataFrame, query);
+      let [result] = ds.transformResultToDataFrames(dataFrame, mockQuery);
 
       expect(result.fields).toHaveLength(2);
       expect(result.length).toBe(3);
@@ -163,13 +142,6 @@ describe('Notebook data source', () => {
     });
 
     it('transforms tabular data with UTC datetime', () => {
-      let query = {
-        refId: '123',
-        path: '/test/notebook',
-        parameters: null,
-        output: 'test_output',
-        cacheTimeout: 0,
-      };
       let dataFrame = {
         type: 'data_frame',
         id: 'test_output',
@@ -185,7 +157,7 @@ describe('Notebook data source', () => {
         },
       };
 
-      let [result] = ds.transformResultToDataFrames(dataFrame, query);
+      let [result] = ds.transformResultToDataFrames(dataFrame, mockQuery);
 
       expect(result.fields).toHaveLength(2);
       expect(result.length).toBe(2);

--- a/systemlink-notebook-datasource/src/DataSource.ts
+++ b/systemlink-notebook-datasource/src/DataSource.ts
@@ -5,7 +5,6 @@
 import defaults from 'lodash/defaults';
 import range from 'lodash/range';
 import Ajv from 'ajv';
-import moment from 'moment';
 
 import { PolicyEvaluator } from '@ni-kismet/helium-uicomponents/library/policyevaluator';
 import {
@@ -17,6 +16,7 @@ import {
   FieldType,
   MetricFindValue,
   DataQueryResponseData,
+  toUtc,
 } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import {
@@ -169,8 +169,8 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
       case 'datetime':
         result.type = FieldType.time;
         if (column.tz === 'UTC') {
-          result.values = values.map(dateString => {
-            return moment.utc(dateString).format();
+          result.values = values.map((dateString) => {
+            return toUtc(dateString).format();
           });
         }
         break;


### PR DESCRIPTION
When serializing outputs from notebooks, Papermill/Scrapbook strips off timezone information from datetimes (for some reason). This is problematic because Grafana will then assume that the dates are in local time, which will be wrong depending on the data returned. However, the Pandas utility function we use to convert dataframes to the tabular format _will_ include the timezone alongside the column type. This change reads that timezone in and converts it correctly if it's UTC. Technically we could try to parse in all named timezones, but we would need to pull in [moment-timezone](https://momentjs.com/timezone/), which is a huge package. Plus it's very unlikely that we'd ever have a use case for returning a datetime that isn't local time or UTC. 