### PR TITLE
[plotly-panel] Validate that dataframes have at least 2 fields

### DIFF
--- a/plotly-panel/src/PlotlyPanel.tsx
+++ b/plotly-panel/src/PlotlyPanel.tsx
@@ -44,6 +44,10 @@ export const PlotlyPanel: React.FC<Props> = (props) => {
 
   var seriesIndex = 0;
   for (const dataframe of data.series) {
+    if (dataframe.fields.length < 2) {
+      throw new Error(`Series '${dataframe.refId}' must contain at least 2 fields.`);
+    }
+
     setDataFrameId(dataframe);
     const { xField, yFields, yFields2 } = getFields(dataframe, props);
     if (!axisLabels.xAxis && xField) {
@@ -199,6 +203,9 @@ const getFields = (frame: DataFrame, props: Props) => {
 const getYFields = (selection: string[], frame: DataFrame, xField: Field | undefined, autoFill = true) => {
   if (autoFill && (!selection || !selection.length)) {
     let yField = frame.fields.find((field) => field !== xField && field.type !== FieldType.time);
+    if (!yField) {
+      return [];
+    }
     return [yField];
   }
 

--- a/plotly-panel/src/module.ts
+++ b/plotly-panel/src/module.ts
@@ -373,6 +373,9 @@ const getFieldOptions = async (context: FieldOverrideContext) => {
   const options: FieldOption[] = [];
   if (context && context.data) {
     for (const frame of context.data) {
+      if (frame.fields.length < 2) {
+        continue;
+      }
       for (const field of frame.fields) {
         if (!options.find((o) => o.label === field.name)) {
           options.push({ value: field.name, label: field.name });


### PR DESCRIPTION
We have a couple bugs ([1](https://dev.azure.com/ni/DevCentral/_workitems/edit/1468499), [2](https://ni.visualstudio.com/DevCentral/_workitems/edit/1210057)) about trying to put scalar data on the plotly panel. This isn't really a valid use case (confirmed with @rfriedma), so this PR makes the panel error with a more useful message.