### PR TITLE
Allow loading unsigned plugins

### DIFF
--- a/config/custom.ini
+++ b/config/custom.ini
@@ -816,7 +816,7 @@ auto_sign_up = true
 ;enable_alpha = false
 ;app_tls_skip_verify_insecure = false
 # Enter a comma-separated list of plugin identifiers to identify plugins that are allowed to be loaded even if they lack a valid signature.
-;allow_loading_unsigned_plugins =
+allow_loading_unsigned_plugins = systemlink-notebook-datasource, ni-systemlink-test-monitor, ni-plotly-panel
 ;marketplace_url = https://grafana.com/grafana/plugins/
 
 #################################### Grafana Image Renderer Plugin ##########################


### PR DESCRIPTION
[As of version 8](https://github.com/grafana/grafana/pull/34716), Grafana no longer allows loading unsigned frontend plugins. This change adds a line to the config file that is installed by the setup script to explicitly allow loading our plugins.