### PR TITLE
[Notebook datasource] Add JSON schema validation for array output

### DIFF
--- a/systemlink-notebook-datasource/src/DataSource.ts
+++ b/systemlink-notebook-datasource/src/DataSource.ts
@@ -81,7 +81,6 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
       const parameters = this.replaceParameterVariables(query.parameters, options);
       const execution = await this.executeNotebook(query.path, parameters, query.cacheTimeout);
       if (execution.status === 'SUCCEEDED') {
-        // TODO: this validation doesn't seem to be working
         if (this.validate(execution.result)) {
           const result = execution.result.result.find((result: any) => result.id === query.output);
           if (!result) {

--- a/systemlink-notebook-datasource/src/data/schema.json
+++ b/systemlink-notebook-datasource/src/data/schema.json
@@ -159,6 +159,36 @@
                                 }
                             }
                         }
+                    },
+                    {
+                        "description": "Array data",
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "type",
+                            "data"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "array"
+                            },
+                            "data": {
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
https://github.com/ni/grafana-plugins/pull/40 added support for an array output type for notebooks. This PR adds that new type to the JSON schema we use to validate notebook execution results. 

I'm not sure why, but when I was working on that previous PR, the JSON schema validation didn't seem to be doing anything. It must have been something weird about my development environment, because it's now working after installing the latest release from GitHub (and therefore throwing an error on the new output type).