### PR TITLE
Update version of Grafana in README to match install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ To run the script, [download the latest release](https://github.com/ni/grafana-p
 
 Caveats:
 - This setup assumes a standard install of SystemLink and Grafana. If you have custom paths, you may need to modify the variables at the start of the script.
-- Grafana v10.2.2 will be installed by default. If you need a different Grafana version, manually install it before running the script.
+- Grafana v11.5.1 will be installed by default. If you need a different Grafana version, manually install it before running the script.
 
 ## Updating an existing Grafana installation on a SystemLink Server instance
 *Note: If you have installed any custom datasources or altered config files, the changes may be overwritten. In that scenario, you should review the install powershell script and manually work through it as appropriate.*
 
-To update an existing install, first upgrade Grafana by downloading and running the following MSI: https://dl.grafana.com/oss/release/grafana-10.2.2.windows-amd64.msi
+To update an existing install, first upgrade Grafana by downloading and running the following MSI: https://dl.grafana.com/oss/release/grafana-11.5.1.windows-amd64.msi
 
 Following that, execute the powershell script in the release archive.
 


### PR DESCRIPTION
In #61 the default installed version of Grafana was updated to 11 but the README still says that 10 is installed. This caused confusion when I was manually scanning our dependencies to see if they were up to date.

I updated the README and verified that the new download link is active.