### PR TITLE
Update to pull latest relevant SLE datasources

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-external_datasources=("workspace" "system" "tag")
+external_datasources=("workspace" "system" "tag" "alarms" "asset" "products" "results")
 external_panels=("plotly")
 local_plugins=("systemlink-test-monitor-datasource" "systemlink-notebook-datasource")
 

--- a/config/custom.ini
+++ b/config/custom.ini
@@ -816,7 +816,7 @@ auto_sign_up = true
 ;enable_alpha = false
 ;app_tls_skip_verify_insecure = false
 # Enter a comma-separated list of plugin identifiers to identify plugins that are allowed to be loaded even if they lack a valid signature.
-allow_loading_unsigned_plugins = ni-slsystem-datasource,ni-sltag-datasource,ni-slworkspace-datasource,ni-plotly-panel,systemlink-notebook-datasource,ni-systemlink-test-monitor
+allow_loading_unsigned_plugins = ni-slsystem-datasource,ni-sltag-datasource,ni-slworkspace-datasource,ni-plotly-panel,systemlink-notebook-datasource,ni-systemlink-test-monitor,ni-slalarms-datasource,ni-slproducts-datasource,ni-sltestresults-datasource,ni-slasset-datasource
 ;marketplace_url = https://grafana.com/grafana/plugins/
 
 #################################### Grafana Image Renderer Plugin ##########################

--- a/config/datasources.yml
+++ b/config/datasources.yml
@@ -24,3 +24,23 @@ datasources:
     type: ni-systemlink-test-monitor
     access: direct
     url: /
+  - name: SystemLink Alarms
+    type:: ni-slalarms-datasource
+    uid: alarms
+    access: direct
+    url: /
+  - name: SystemLink Products
+    type: ni-slproducts-datasource
+    uid: products
+    access: direct
+    url: /
+  - name: SystemLink Test Results
+    type: ni-sltestresults-datasource
+    uid: testresults
+    access: direct
+    url: /
+  - name: SystemLink Assets
+    type: "ni-slasset-datasource"
+    uid: assets
+    access: direct
+    url: /


### PR DESCRIPTION
I went ahead and added the products, alarms, testresults and asset datasources and updated the others to the current version.

Notes: 
* The Alarms datasource seems to not yet be fully baked, but as a result it's also not showing up in the list of datasources. With the work I've done in this PR, it should automatically populate once the actual implementation is done and the subrepo is updated.
* Products in SLE have a concept of workspaces while SLS products do not. The product datasource applies a projection to the query, which by default includes 'workspace' and thus errors out. If you deselect workspace, everything else seems to function as it should. After weighing the options, I propose we flag it as a "Known Issue" that the products plugin seems broken on load, and then document the fact you just have to deselect the 'workspace' parameter.


Closes #60 

